### PR TITLE
Add configurable 3s timeline update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://<domain>/playback/presentation/2.3/<recordId>
 ## URL query strings
 
 - frequency:
-  - `f=<value>`: renders per second (e.g., 5)
+  - `f=<value>`: renders per second (e.g., 5; use decimals such as `0.333` for ~3-second updates)
 
 - layout:
   - `l=content`: focus on content
@@ -59,6 +59,7 @@ https://<domain>/playback/presentation/2.3/<recordId>
   - `default`: fallback [`en`]
 
 - player: primary media configuration
+  - `timeUpdateIntervalSeconds`: seconds between timeline refreshes while playing (default `3`; overrides `rps` when provided)
   - `rps`: renders per second
   - `rates`: speed rates
 

--- a/src/components/chat/messages/message.js
+++ b/src/components/chat/messages/message.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Info from './info';
 import Margin from './margin';
 import player from 'utils/player';
+import { dispatchTimeUpdate } from 'utils/events';
 import './index.scss';
 
 const propTypes = {
@@ -43,6 +44,7 @@ const Message = ({
 }) => {
   const handleOnClick = () => {
     player.primary.currentTime(timestamp);
+    dispatchTimeUpdate(timestamp);
   };
 
   return (

--- a/src/components/thumbnails/item.js
+++ b/src/components/thumbnails/item.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Thumbnail from './thumbnail';
 import { handleOnEnterPress } from 'utils/data/handlers';
 import player from 'utils/player';
+import { dispatchTimeUpdate } from 'utils/events';
 import './index.scss';
 
 const propTypes = {
@@ -46,7 +47,10 @@ const Item = ({
   }
 
   const handleOnClick = () => {
-    if (interactive) player.primary.currentTime(item.timestamp);
+    if (interactive) {
+      player.primary.currentTime(item.timestamp);
+      dispatchTimeUpdate(item.timestamp);
+    }
   };
 
   return (

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -2,12 +2,13 @@ import React, { useEffect, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import videojs from 'video.js/core.es.js';
 import { player as config } from 'config';
-import { EVENTS, ID } from 'utils/constants';
+import { ID } from 'utils/constants';
 import { buildFileURL } from 'utils/data';
 import logger from 'utils/logger';
-import { getFrequency, getTime } from 'utils/params';
+import { getTime } from 'utils/params';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
+import { dispatchTimeUpdate, getTimeUpdateIntervalMs } from 'utils/events';
 import './index.scss';
 
 const intlMessages = defineMessages({
@@ -44,11 +45,6 @@ const buildOptions = (sources) => ({
     nativeTextTracks: true,
   },
 });
-
-const dispatchTimeUpdate = (time) => {
-  const event = new CustomEvent(EVENTS.TIME_UPDATE, { detail: { time }});
-  document.dispatchEvent(event);
-};
 
 const Webcams = () => {
   const intl = useIntl();
@@ -124,14 +120,23 @@ const Webcams = () => {
       player.webcams.play();
 
       player.webcams.on('play', () => {
-        const frequency = getFrequency();
-        interval.current = setInterval(() => {
-          dispatchTimeUpdate(player.webcams.currentTime());
-        }, 1000 / (frequency || config.rps));
+        const intervalMs = getTimeUpdateIntervalMs();
+
+        clearInterval(interval.current);
+
+        if (Number.isFinite(intervalMs) && intervalMs > 0) {
+          interval.current = setInterval(() => {
+            dispatchTimeUpdate(player.webcams.currentTime());
+          }, intervalMs);
+        }
       });
 
       player.webcams.on('pause', () => {
         clearInterval(interval.current);
+      });
+
+      player.webcams.on('seeking', () => {
+        dispatchTimeUpdate(player.webcams.currentTime());
       });
 
       player.webcams.on('seeked', () => {

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -1,20 +1,11 @@
 import React, { useEffect, useRef } from 'react';
-import {
-  defineMessages,
-  useIntl,
-} from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 import videojs from 'video.js/core.es.js';
 import { player as config } from 'config';
-import {
-  EVENTS,
-  ID,
-} from 'utils/constants';
+import { EVENTS, ID } from 'utils/constants';
 import { buildFileURL } from 'utils/data';
 import logger from 'utils/logger';
-import {
-  getFrequency,
-  getTime,
-} from 'utils/params';
+import { getFrequency, getTime } from 'utils/params';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
 import './index.scss';
@@ -28,59 +19,31 @@ const intlMessages = defineMessages({
 
 const buildSources = () => {
   if (storage.fallback) {
-    return [
-      {
-        src: buildFileURL('audio/audio.webm'),
-        type: 'audio/webm',
-      },
-    ];
+    return [{ src: buildFileURL('audio/audio.webm'), type: 'audio/webm' }];
   }
-
   return [
-    {
-      src: buildFileURL('video/webcams.mp4'),
-      type: 'video/mp4',
-    }, {
-      src: buildFileURL('video/webcams.webm'),
-      type: 'video/webm',
-    },
+    { src: buildFileURL('video/webcams.mp4'),  type: 'video/mp4'  },
+    { src: buildFileURL('video/webcams.webm'), type: 'video/webm' },
   ].filter(source => storage.media.find(m => source.type.includes(m)));
 };
 
-const buildTracks = () => {
-  return storage.captions.map(lang => {
-    const {
-      locale,
-      localeName,
-    } = lang;
-
-    return {
-      kind: 'captions',
-      src: buildFileURL(`caption_${locale}.vtt`),
-      srclang: locale,
-      label: localeName,
-    };
-  });
-};
-
-const buildOptions = (sources, tracks) => {
-  return {
-    controlBar: {
-      fullscreenToggle: false,
-      pictureInPictureToggle: false,
-      volumePanel: {
-        inline: false,
-        vertical: true,
-      },
-    },
-    controls: true,
-    fill: true,
-    inactivityTimeout: 0,
-    playbackRates: config.rates,
-    sources: sources.current,
-    tracks: tracks.current,
-  };
-};
+const buildOptions = (sources) => ({
+  autoplay: true,
+  controlBar: {
+    fullscreenToggle: false,
+    pictureInPictureToggle: false,
+    volumePanel: { inline: false, vertical: true },
+  },
+  controls: true,
+  fill: true,
+  inactivityTimeout: 0,
+  playbackRates: config.rates,
+  sources: sources.current,
+  // Important: use native text tracks so the browser fires the standard events
+  html5: {
+    nativeTextTracks: true,
+  },
+});
 
 const dispatchTimeUpdate = (time) => {
   const event = new CustomEvent(EVENTS.TIME_UPDATE, { detail: { time }});
@@ -89,56 +52,166 @@ const dispatchTimeUpdate = (time) => {
 
 const Webcams = () => {
   const intl = useIntl();
-  const sources = useRef(buildSources());
-  const tracks = useRef(buildTracks());
-  const element = useRef();
-  const interval = useRef();
+
+  const sources      = useRef(buildSources());
+  const tracks       = useRef(storage.captions || []); // [{ locale, localeName }]
+  const element      = useRef();
+  const interval     = useRef();
+  const textTracks   = useRef();
+  const trackHandler = useRef();
+  const trackElsByLabel = useRef({});
 
   useEffect(() => {
-    if (!player.webcams) {
-      const video = element.current;
-      if (!video) return;
+    if (player.webcams) return;
 
-      player.webcams = videojs(video, buildOptions(sources, tracks), () => {
-        player.webcams.on('play', () => {
-          const frequency = getFrequency();
-          interval.current = setInterval(() => {
-            const currentTime = player.webcams.currentTime();
-            dispatchTimeUpdate(currentTime);
-          }, 1000 / (frequency ? frequency : config.rps));
-        });
+    const video = element.current;
+    if (!video) return;
 
-        player.webcams.on('pause', () => clearInterval(interval.current));
+    // Clean any legacy track nodes
+    video.querySelectorAll('track').forEach(t => t.remove());
+    trackElsByLabel.current = {};
 
-        player.webcams.on('seeked', () => {
-          const currentTime = player.webcams.currentTime();
-          dispatchTimeUpdate(currentTime);
-        });
+    // Create <track> nodes WITHOUT src; stash the real URL in data attribute
+    tracks.current.forEach(({ locale, localeName }) => {
+      const el = document.createElement('track');
+      el.kind    = 'captions';
+      el.label   = localeName;
+      el.srclang = (locale || '').replace(/_/g, '-').toLowerCase();
+      // Do NOT set el.src now; we will attach it on selection
+      el.setAttribute('data-vtt-src', buildFileURL(`caption_${locale}.vtt`));
+      trackElsByLabel.current[String(localeName || '').toLowerCase()] = el;
+      video.appendChild(el);
+    });
 
-        const time = getTime();
-        if (time) {
-          player.webcams.on('loadedmetadata', () => {
-            const duration = player.webcams.duration();
-            if (time < duration) {
-              player.webcams.currentTime(time);
-            }
-          });
+    // Helper: robustly force a reload when we assign src the first time
+    const loadVttSrc = (trackEl) => {
+      if (!trackEl) return;
+      if (trackEl.dataset.loaded === 'true') return;
+
+      const realSrc = trackEl.dataset.vttSrc;
+      if (!realSrc) return;
+
+      // UX hint while we fetch
+      player.webcams?.addClass?.('vjs-waiting');
+
+      const onFinish = () => {
+        trackEl.dataset.loaded = 'true';
+        player.webcams?.removeClass?.('vjs-waiting');
+        trackEl.removeEventListener('load', onFinish);
+        trackEl.removeEventListener('error', onFinish);
+      };
+
+      trackEl.addEventListener('load', onFinish, { once: true });
+      trackEl.addEventListener('error', onFinish, { once: true });
+
+      // Some browsers ignore a single src mutation; clear first then set next tick
+      trackEl.setAttribute('src', '');
+      (window.requestAnimationFrame || setTimeout)(() => {
+        trackEl.setAttribute('src', realSrc);
+
+        // Ensure the native TextTrack becomes active after setting src
+        const nativeTrack = trackEl.track; // HTMLTrackElement.track (TextTrack)
+        if (nativeTrack) {
+          nativeTrack.mode = 'disabled';
+          (window.requestAnimationFrame || setTimeout)(() => {
+            nativeTrack.mode = 'showing';
+          }, 0);
         }
-      });
-      logger.debug(ID.WEBCAMS, 'mounted');
-    }
-  }, []);
+      }, 0);
+    };
 
-  useEffect(() => {
+    player.webcams = videojs(video, buildOptions(sources), () => {
+      player.webcams.play();
+
+      player.webcams.on('play', () => {
+        const frequency = getFrequency();
+        interval.current = setInterval(() => {
+          dispatchTimeUpdate(player.webcams.currentTime());
+        }, 1000 / (frequency || config.rps));
+      });
+
+      player.webcams.on('pause', () => {
+        clearInterval(interval.current);
+      });
+
+      player.webcams.on('seeked', () => {
+        dispatchTimeUpdate(player.webcams.currentTime());
+      });
+
+      const time = getTime();
+      if (time) {
+        player.webcams.on('loadedmetadata', () => {
+          const duration = player.webcams.duration();
+          if (time < duration) player.webcams.currentTime(time);
+        });
+      }
+
+      // captions lazy-load
+      textTracks.current = player.webcams.textTracks();
+
+      // Disable all initially (prevent auto show/load)
+      for (let i = 0; i < textTracks.current.length; i += 1) {
+        const tt = textTracks.current[i];
+        if (tt && (tt.kind === 'captions' || tt.kind === 'subtitles')) {
+          tt.mode = 'disabled';
+        }
+      }
+
+      // On caption selection, attach real src if needed and force it to load
+      trackHandler.current = () => {
+        const tts = textTracks.current;
+        if (!tts) return;
+
+        for (let i = 0; i < tts.length; i += 1) {
+          const tt = tts[i];
+          if (!(tt && (tt.kind === 'captions' || tt.kind === 'subtitles'))) continue;
+
+          if (tt.mode === 'showing') {
+            const labelLower = String(tt.label || '').toLowerCase();
+            const trackEl =
+              trackElsByLabel.current[labelLower] ||
+              element.current.querySelector(
+                `track[srclang="${(tt.language || '').toLowerCase()}"]`
+              );
+
+            loadVttSrc(trackEl);
+          }
+        }
+      };
+
+      // Cover both native and Video.js events
+      textTracks.current.addEventListener('change', trackHandler.current);
+      player.webcams.on('texttrackchange', trackHandler.current);
+
+      // Optional: auto-select a default caption (match UI locale)
+      const preferred = (storage?.locale || navigator.language || '').split('-')[0];
+      if (preferred) {
+        const tts = textTracks.current;
+        for (let i = 0; i < tts.length; i += 1) {
+          const tt = tts[i];
+          if ((tt.language || '').toLowerCase().startsWith(preferred.toLowerCase())) {
+            tt.mode = 'showing'; // triggers handler → loads real VTT
+            break;
+          }
+        }
+      }
+    });
+
+    logger.debug(ID.WEBCAMS, 'mounted');
+
     return () => {
       if (player.webcams) {
+        if (textTracks.current && trackHandler.current) {
+          textTracks.current.removeEventListener('change', trackHandler.current);
+          player.webcams?.off?.('texttrackchange', trackHandler.current);
+        }
+        clearInterval(interval.current);
         player.webcams.dispose();
         player.webcams = null;
-        logger.debug(ID.WEBCAMS, 'unmounted');
       }
+      logger.debug(ID.WEBCAMS, 'unmounted');
     };
   }, []);
-
 
   return (
     <div
@@ -151,6 +224,8 @@ const Webcams = () => {
           className="video-js"
           playsInline
           preload="auto"
+          // Set this when VTT or media may be on a different origin
+          crossOrigin="anonymous"
           ref={element}
         />
       </div>

--- a/src/config.json
+++ b/src/config.json
@@ -35,6 +35,7 @@
     "webm"
   ],
   "player": {
+    "timeUpdateIntervalSeconds": 3,
     "rps": 10,
     "rates": [ 0.5, 1, 1.25, 1.5, 1.75, 2 ]
   },

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -1,6 +1,7 @@
 import { getCurrentDataIndex } from 'utils/data';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
+import { dispatchTimeUpdate } from 'utils/events';
 
 const play = () => {
   if (player.primary.paused()) {
@@ -30,12 +31,19 @@ const seek = (seconds) => {
   const max = player.primary.duration();
   const time = player.primary.currentTime() + seconds;
 
+  let nextTime;
+
   if (time < min) {
-    player.primary.currentTime(min);
+    nextTime = min;
   } else if (time > max) {
-    player.primary.currentTime(max);
+    nextTime = max;
   } else {
-    player.primary.currentTime(time);
+    nextTime = time;
+  }
+
+  if (typeof nextTime === 'number') {
+    player.primary.currentTime(nextTime);
+    dispatchTimeUpdate(nextTime);
   }
 };
 
@@ -60,6 +68,7 @@ const skip = (change) => {
 
   if (typeof timestamp !== 'undefined') {
     player.primary.currentTime(timestamp);
+    dispatchTimeUpdate(timestamp);
   }
 };
 

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,0 +1,45 @@
+import { player as playerConfig } from 'config';
+import { EVENTS } from 'utils/constants';
+import { getFrequency } from 'utils/params';
+
+const DEFAULT_TIME_UPDATE_INTERVAL_MS = 3000;
+
+const isPositiveNumber = (value) => (
+  typeof value === 'number'
+  && !Number.isNaN(value)
+  && value > 0
+);
+
+const getTimeUpdateIntervalMs = () => {
+  let frequency = null;
+
+  if (typeof window !== 'undefined') {
+    frequency = getFrequency();
+  }
+
+  if (isPositiveNumber(frequency)) {
+    return 1000 / frequency;
+  }
+
+  const { timeUpdateIntervalSeconds, rps } = playerConfig || {};
+
+  if (isPositiveNumber(timeUpdateIntervalSeconds)) {
+    return timeUpdateIntervalSeconds * 1000;
+  }
+
+  if (isPositiveNumber(rps)) {
+    return 1000 / rps;
+  }
+
+  return DEFAULT_TIME_UPDATE_INTERVAL_MS;
+};
+
+const dispatchTimeUpdate = (time) => {
+  const event = new CustomEvent(EVENTS.TIME_UPDATE, { detail: { time }});
+  document.dispatchEvent(event);
+};
+
+export {
+  getTimeUpdateIntervalMs,
+  dispatchTimeUpdate,
+};


### PR DESCRIPTION
## Summary
- add a utility to resolve the TIME_UPDATE dispatch interval with a 3-second default
- use the new helper so play events clear the previous timer and respect the configured cadence
- document the timeUpdateIntervalSeconds option for changing the default refresh delay

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9af4b3e4832ab368d0da28d2ef7a