### PR TITLE
Lazy load captions and default to API locale

### DIFF
--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -11,6 +11,7 @@ import { buildFileURL } from 'utils/data';
 import logger from 'utils/logger';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
+import { parseCaptionsData, setupLazyCaptions } from 'utils/captions';
 import './index.scss';
 
 const intlMessages = defineMessages({
@@ -37,21 +38,39 @@ const buildOptions = (sources) => {
     controls: false,
     fill: true,
     sources: sources.current,
+    html5: {
+      nativeTextTracks: true,
+    },
   };
 };
 
 const Screenshare = () => {
   const intl = useIntl();
   const currentContent = useCurrentContent();
+  const {
+    locales: captionLocales,
+    defaultLocale: captionsDefaultLocale,
+  } = parseCaptionsData(storage.captions);
+
   const sources = useRef(buildSources());
+  const tracks = useRef(captionLocales);
+  const defaultCaptionLocale = useRef(captionsDefaultLocale);
   const element = useRef();
+  const captionsCleanup = useRef(() => {});
 
   useEffect(() => {
     if (!player.screenshare) {
       const video = element.current;
       if (!video) return;
 
-      player.screenshare = videojs(video, buildOptions(sources), () => {});
+      player.screenshare = videojs(video, buildOptions(sources), () => {
+        captionsCleanup.current = setupLazyCaptions({
+          playerInstance: player.screenshare,
+          videoElement: video,
+          tracks: tracks.current,
+          defaultLocale: defaultCaptionLocale.current,
+        });
+      });
       logger.debug(ID.SCREENSHARE, 'mounted');
     }
   }, []);
@@ -59,6 +78,10 @@ const Screenshare = () => {
   useEffect(() => {
     return () => {
       if (player.screenshare) {
+        if (captionsCleanup.current) {
+          captionsCleanup.current();
+          captionsCleanup.current = () => {};
+        }
         player.screenshare.dispose();
         player.screenshare = null;
         logger.debug(ID.SCREENSHARE, 'unmounted');
@@ -77,6 +100,7 @@ const Screenshare = () => {
           className="video-js"
           playsInline
           preload="auto"
+          crossOrigin="anonymous"
           ref={element}
         />
       </div>

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -8,134 +8,9 @@ import logger from 'utils/logger';
 import { getFrequency, getTime } from 'utils/params';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
+import layout from 'utils/layout';
+import { parseCaptionsData, setupLazyCaptions } from 'utils/captions';
 import './index.scss';
-
-const CAPTION_TRACK_KINDS = ['captions', 'subtitles'];
-
-const normalizeLocale = (locale) => {
-  if (!locale) return '';
-
-  return String(locale).replace(/_/g, '-').toLowerCase();
-};
-
-const getLocaleString = (value) => {
-  if (!value) return '';
-  if (typeof value === 'string') return value;
-  if (typeof value === 'object') {
-    return (
-      value.locale ||
-      value.language ||
-      value.lang ||
-      value.code ||
-      ''
-    );
-  }
-
-  return '';
-};
-
-const toArray = (value) => {
-  if (!value) return [];
-  if (Array.isArray(value)) return value;
-  if (typeof value === 'object') return Object.values(value);
-
-  return [];
-};
-
-const findDefaultLocale = (locales = []) => {
-  if (!Array.isArray(locales)) return '';
-
-  const defaultEntry = locales.find(item => {
-    if (!item || typeof item !== 'object') return false;
-
-    return (
-      item.default === true ||
-      item.isDefault === true ||
-      item.defaultLocale === true ||
-      item.default_locale === true
-    );
-  });
-
-  if (!defaultEntry) return '';
-
-  return (
-    getLocaleString(defaultEntry.defaultLocale) ||
-    getLocaleString(defaultEntry.default_locale) ||
-    getLocaleString(defaultEntry)
-  );
-};
-
-const parseCaptionsData = (captionsData) => {
-  if (!captionsData) {
-    return { locales: [], defaultLocale: '' };
-  }
-
-  if (Array.isArray(captionsData)) {
-    return {
-      locales: captionsData,
-      defaultLocale: findDefaultLocale(captionsData),
-    };
-  }
-
-  if (typeof captionsData === 'object') {
-    const localesSource =
-      captionsData.locales ??
-      captionsData.captions ??
-      captionsData.locale ??
-      captionsData.tracks ??
-      captionsData.languages ??
-      null;
-
-    const locales = toArray(localesSource);
-
-    let defaultLocale =
-      getLocaleString(captionsData.defaultLocale) ||
-      getLocaleString(captionsData.default_locale) ||
-      getLocaleString(captionsData.default);
-
-    if (!defaultLocale) {
-      defaultLocale = findDefaultLocale(locales);
-    }
-
-    return {
-      locales,
-      defaultLocale,
-    };
-  }
-
-  return { locales: [], defaultLocale: '' };
-};
-
-const getTrackLocale = (track) => {
-  if (!track || typeof track !== 'object') return '';
-
-  return (
-    (typeof track.locale === 'string' && track.locale) ||
-    (typeof track.language === 'string' && track.language) ||
-    (typeof track.lang === 'string' && track.lang) ||
-    (typeof track.code === 'string' && track.code) ||
-    getLocaleString(track.defaultLocale) ||
-    getLocaleString(track.default_locale) ||
-    ''
-  );
-};
-
-const getTrackLabel = (track) => {
-  if (!track || typeof track !== 'object') return '';
-
-  return (
-    (typeof track.localeName === 'string' && track.localeName) ||
-    (typeof track.label === 'string' && track.label) ||
-    (typeof track.name === 'string' && track.name) ||
-    getTrackLocale(track)
-  );
-};
-
-const isCaptionTextTrack = (textTrack) => {
-  if (!textTrack) return false;
-
-  return CAPTION_TRACK_KINDS.includes(textTrack.kind);
-};
 
 const intlMessages = defineMessages({
   aria: {
@@ -190,97 +65,15 @@ const Webcams = () => {
   const defaultCaptionLocale  = useRef(captionsDefaultLocale);
   const element               = useRef();
   const interval              = useRef();
-  const textTracks            = useRef();
-  const trackHandler          = useRef();
-  const trackElsByLabel       = useRef({});
-  const trackElsByLocale      = useRef({});
+  const captionsCleanup       = useRef(() => {});
+
+  const handleCaptionsInWebcams = !layout.screenshare;
 
   useEffect(() => {
     if (player.webcams) return;
 
     const video = element.current;
     if (!video) return;
-
-    // Clean any legacy track nodes
-    video.querySelectorAll('track').forEach(t => t.remove());
-    trackElsByLabel.current = {};
-    trackElsByLocale.current = {};
-
-    // Create <track> nodes WITHOUT src; stash the real URL in data attribute
-    tracks.current.forEach((trackData) => {
-      const locale = getTrackLocale(trackData);
-      if (!locale) return;
-
-      const label = getTrackLabel(trackData) || locale;
-      const el = document.createElement('track');
-      el.kind    = 'captions';
-      el.label   = label;
-
-      const srclang = normalizeLocale(locale);
-      if (srclang) el.srclang = srclang;
-
-      // Do NOT set el.src now; we will attach it on selection
-      el.setAttribute('data-vtt-src', buildFileURL(`caption_${locale}.vtt`));
-
-      trackElsByLabel.current[String(label || '').toLowerCase()] = el;
-      if (srclang) trackElsByLocale.current[srclang] = el;
-
-      video.appendChild(el);
-    });
-
-    // Helper: robustly force a reload when we assign src the first time
-    const loadVttSrc = (trackEl) => {
-      if (!trackEl) return;
-      if (trackEl.dataset.loaded === 'true') return;
-      if (trackEl.dataset.loading === 'true') return;
-
-      const realSrc = trackEl.dataset.vttSrc;
-      if (!realSrc) return;
-
-      // UX hint while we fetch
-      player.webcams?.addClass?.('vjs-waiting');
-
-      trackEl.dataset.loading = 'true';
-
-      const onFinish = () => {
-        trackEl.dataset.loaded = 'true';
-        trackEl.dataset.loading = 'false';
-        player.webcams?.removeClass?.('vjs-waiting');
-        trackEl.removeEventListener('load', onFinish);
-        trackEl.removeEventListener('error', onFinish);
-      };
-
-      trackEl.addEventListener('load', onFinish, { once: true });
-      trackEl.addEventListener('error', onFinish, { once: true });
-
-      // Some browsers ignore a single src mutation; clear first then set next tick
-      trackEl.setAttribute('src', '');
-      (window.requestAnimationFrame || setTimeout)(() => {
-        trackEl.setAttribute('src', realSrc);
-
-        // Ensure the native TextTrack becomes active after setting src
-        const nativeTrack = trackEl.track; // HTMLTrackElement.track (TextTrack)
-        if (nativeTrack) {
-          nativeTrack.mode = 'disabled';
-          (window.requestAnimationFrame || setTimeout)(() => {
-            nativeTrack.mode = 'showing';
-          }, 0);
-        }
-      }, 0);
-    };
-
-    const getTrackElementForTextTrack = (textTrack) => {
-      if (!textTrack) return null;
-
-      const language = normalizeLocale(textTrack.language);
-      const labelLower = String(textTrack.label || '').toLowerCase();
-
-      return (
-        (language && trackElsByLocale.current[language]) ||
-        trackElsByLabel.current[labelLower] ||
-        (language ? video.querySelector(`track[srclang="${language}"]`) : null)
-      );
-    };
 
     player.webcams = videojs(video, buildOptions(sources), () => {
       player.webcams.play();
@@ -308,99 +101,13 @@ const Webcams = () => {
         });
       }
 
-      // captions lazy-load
-      textTracks.current = player.webcams.textTracks();
-
-      // Disable all initially (prevent auto show/load)
-      for (let i = 0; i < textTracks.current.length; i += 1) {
-        const tt = textTracks.current[i];
-        if (isCaptionTextTrack(tt)) {
-          tt.mode = 'disabled';
-        }
-      }
-
-      // On caption selection, attach real src if needed and force it to load
-      trackHandler.current = () => {
-        const tts = textTracks.current;
-        if (!tts) return;
-
-        for (let i = 0; i < tts.length; i += 1) {
-          const tt = tts[i];
-          if (!isCaptionTextTrack(tt)) continue;
-
-          if (tt.mode === 'showing') {
-            const trackEl = getTrackElementForTextTrack(tt);
-
-            loadVttSrc(trackEl);
-          }
-        }
-      };
-
-      // Cover both native and Video.js events
-      textTracks.current.addEventListener('change', trackHandler.current);
-      player.webcams.on('texttrackchange', trackHandler.current);
-
-      const selectCaptionByLocale = (rawLocale) => {
-        const normalizedTarget = normalizeLocale(rawLocale);
-        if (!normalizedTarget) return false;
-
-        const tts = textTracks.current;
-        if (!tts) return false;
-
-        let fallbackMatch = null;
-
-        for (let i = 0; i < tts.length; i += 1) {
-          const tt = tts[i];
-          if (!isCaptionTextTrack(tt)) continue;
-
-          const trackEl = getTrackElementForTextTrack(tt);
-          if (!trackEl) continue;
-
-          const trackLocale =
-            normalizeLocale(tt.language) ||
-            normalizeLocale(trackEl.srclang);
-
-          if (!trackLocale) continue;
-
-          if (trackLocale === normalizedTarget) {
-            tt.mode = 'showing';
-            loadVttSrc(trackEl);
-            return true;
-          }
-
-          if (!fallbackMatch) {
-            const [targetLanguage] = normalizedTarget.split('-');
-            const [trackLanguage] = trackLocale.split('-');
-            if (targetLanguage && trackLanguage && targetLanguage === trackLanguage) {
-              fallbackMatch = { tt, trackEl };
-            }
-          }
-        }
-
-        if (fallbackMatch) {
-          fallbackMatch.tt.mode = 'showing';
-          loadVttSrc(fallbackMatch.trackEl);
-          return true;
-        }
-
-        return false;
-      };
-
-      // Auto-select caption defaulting to API-provided locale and browser locale fallback
-      const localeCandidates = [
-        defaultCaptionLocale.current,
-        navigator.language,
-      ].filter(Boolean);
-
-      for (let index = 0; index < localeCandidates.length; index += 1) {
-        const candidate = localeCandidates[index];
-        if (selectCaptionByLocale(candidate)) break;
-
-        const normalizedCandidate = normalizeLocale(candidate);
-        const [baseLanguage] = normalizedCandidate.split('-');
-        if (baseLanguage && baseLanguage !== normalizedCandidate) {
-          if (selectCaptionByLocale(baseLanguage)) break;
-        }
+      if (handleCaptionsInWebcams) {
+        captionsCleanup.current = setupLazyCaptions({
+          playerInstance: player.webcams,
+          videoElement: video,
+          tracks: tracks.current,
+          defaultLocale: defaultCaptionLocale.current,
+        });
       }
     });
 
@@ -408,9 +115,9 @@ const Webcams = () => {
 
     return () => {
       if (player.webcams) {
-        if (textTracks.current && trackHandler.current) {
-          textTracks.current.removeEventListener('change', trackHandler.current);
-          player.webcams?.off?.('texttrackchange', trackHandler.current);
+        if (captionsCleanup.current) {
+          captionsCleanup.current();
+          captionsCleanup.current = () => {};
         }
         clearInterval(interval.current);
         player.webcams.dispose();

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -10,6 +10,133 @@ import storage from 'utils/data/storage';
 import player from 'utils/player';
 import './index.scss';
 
+const CAPTION_TRACK_KINDS = ['captions', 'subtitles'];
+
+const normalizeLocale = (locale) => {
+  if (!locale) return '';
+
+  return String(locale).replace(/_/g, '-').toLowerCase();
+};
+
+const getLocaleString = (value) => {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') {
+    return (
+      value.locale ||
+      value.language ||
+      value.lang ||
+      value.code ||
+      ''
+    );
+  }
+
+  return '';
+};
+
+const toArray = (value) => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'object') return Object.values(value);
+
+  return [];
+};
+
+const findDefaultLocale = (locales = []) => {
+  if (!Array.isArray(locales)) return '';
+
+  const defaultEntry = locales.find(item => {
+    if (!item || typeof item !== 'object') return false;
+
+    return (
+      item.default === true ||
+      item.isDefault === true ||
+      item.defaultLocale === true ||
+      item.default_locale === true
+    );
+  });
+
+  if (!defaultEntry) return '';
+
+  return (
+    getLocaleString(defaultEntry.defaultLocale) ||
+    getLocaleString(defaultEntry.default_locale) ||
+    getLocaleString(defaultEntry)
+  );
+};
+
+const parseCaptionsData = (captionsData) => {
+  if (!captionsData) {
+    return { locales: [], defaultLocale: '' };
+  }
+
+  if (Array.isArray(captionsData)) {
+    return {
+      locales: captionsData,
+      defaultLocale: findDefaultLocale(captionsData),
+    };
+  }
+
+  if (typeof captionsData === 'object') {
+    const localesSource =
+      captionsData.locales ??
+      captionsData.captions ??
+      captionsData.locale ??
+      captionsData.tracks ??
+      captionsData.languages ??
+      null;
+
+    const locales = toArray(localesSource);
+
+    let defaultLocale =
+      getLocaleString(captionsData.defaultLocale) ||
+      getLocaleString(captionsData.default_locale) ||
+      getLocaleString(captionsData.default);
+
+    if (!defaultLocale) {
+      defaultLocale = findDefaultLocale(locales);
+    }
+
+    return {
+      locales,
+      defaultLocale,
+    };
+  }
+
+  return { locales: [], defaultLocale: '' };
+};
+
+const getTrackLocale = (track) => {
+  if (!track || typeof track !== 'object') return '';
+
+  return (
+    (typeof track.locale === 'string' && track.locale) ||
+    (typeof track.language === 'string' && track.language) ||
+    (typeof track.lang === 'string' && track.lang) ||
+    (typeof track.code === 'string' && track.code) ||
+    getLocaleString(track.defaultLocale) ||
+    getLocaleString(track.default_locale) ||
+    ''
+  );
+};
+
+const getTrackLabel = (track) => {
+  if (!track || typeof track !== 'object') return '';
+
+  return (
+    (typeof track.localeName === 'string' && track.localeName) ||
+    (typeof track.label === 'string' && track.label) ||
+    (typeof track.name === 'string' && track.name) ||
+    getTrackLocale(track)
+  );
+};
+
+const isCaptionTextTrack = (textTrack) => {
+  if (!textTrack) return false;
+
+  return CAPTION_TRACK_KINDS.includes(textTrack.kind);
+};
+
 const intlMessages = defineMessages({
   aria: {
     id: 'player.webcams.wrapper.aria',
@@ -53,13 +180,20 @@ const dispatchTimeUpdate = (time) => {
 const Webcams = () => {
   const intl = useIntl();
 
-  const sources      = useRef(buildSources());
-  const tracks       = useRef(storage.captions || []); // [{ locale, localeName }]
-  const element      = useRef();
-  const interval     = useRef();
-  const textTracks   = useRef();
-  const trackHandler = useRef();
-  const trackElsByLabel = useRef({});
+  const {
+    locales: captionLocales,
+    defaultLocale: captionsDefaultLocale,
+  } = parseCaptionsData(storage.captions);
+
+  const sources               = useRef(buildSources());
+  const tracks                = useRef(captionLocales); // [{ locale, localeName }]
+  const defaultCaptionLocale  = useRef(captionsDefaultLocale);
+  const element               = useRef();
+  const interval              = useRef();
+  const textTracks            = useRef();
+  const trackHandler          = useRef();
+  const trackElsByLabel       = useRef({});
+  const trackElsByLocale      = useRef({});
 
   useEffect(() => {
     if (player.webcams) return;
@@ -70,16 +204,27 @@ const Webcams = () => {
     // Clean any legacy track nodes
     video.querySelectorAll('track').forEach(t => t.remove());
     trackElsByLabel.current = {};
+    trackElsByLocale.current = {};
 
     // Create <track> nodes WITHOUT src; stash the real URL in data attribute
-    tracks.current.forEach(({ locale, localeName }) => {
+    tracks.current.forEach((trackData) => {
+      const locale = getTrackLocale(trackData);
+      if (!locale) return;
+
+      const label = getTrackLabel(trackData) || locale;
       const el = document.createElement('track');
       el.kind    = 'captions';
-      el.label   = localeName;
-      el.srclang = (locale || '').replace(/_/g, '-').toLowerCase();
+      el.label   = label;
+
+      const srclang = normalizeLocale(locale);
+      if (srclang) el.srclang = srclang;
+
       // Do NOT set el.src now; we will attach it on selection
       el.setAttribute('data-vtt-src', buildFileURL(`caption_${locale}.vtt`));
-      trackElsByLabel.current[String(localeName || '').toLowerCase()] = el;
+
+      trackElsByLabel.current[String(label || '').toLowerCase()] = el;
+      if (srclang) trackElsByLocale.current[srclang] = el;
+
       video.appendChild(el);
     });
 
@@ -87,6 +232,7 @@ const Webcams = () => {
     const loadVttSrc = (trackEl) => {
       if (!trackEl) return;
       if (trackEl.dataset.loaded === 'true') return;
+      if (trackEl.dataset.loading === 'true') return;
 
       const realSrc = trackEl.dataset.vttSrc;
       if (!realSrc) return;
@@ -94,8 +240,11 @@ const Webcams = () => {
       // UX hint while we fetch
       player.webcams?.addClass?.('vjs-waiting');
 
+      trackEl.dataset.loading = 'true';
+
       const onFinish = () => {
         trackEl.dataset.loaded = 'true';
+        trackEl.dataset.loading = 'false';
         player.webcams?.removeClass?.('vjs-waiting');
         trackEl.removeEventListener('load', onFinish);
         trackEl.removeEventListener('error', onFinish);
@@ -118,6 +267,19 @@ const Webcams = () => {
           }, 0);
         }
       }, 0);
+    };
+
+    const getTrackElementForTextTrack = (textTrack) => {
+      if (!textTrack) return null;
+
+      const language = normalizeLocale(textTrack.language);
+      const labelLower = String(textTrack.label || '').toLowerCase();
+
+      return (
+        (language && trackElsByLocale.current[language]) ||
+        trackElsByLabel.current[labelLower] ||
+        (language ? video.querySelector(`track[srclang="${language}"]`) : null)
+      );
     };
 
     player.webcams = videojs(video, buildOptions(sources), () => {
@@ -152,7 +314,7 @@ const Webcams = () => {
       // Disable all initially (prevent auto show/load)
       for (let i = 0; i < textTracks.current.length; i += 1) {
         const tt = textTracks.current[i];
-        if (tt && (tt.kind === 'captions' || tt.kind === 'subtitles')) {
+        if (isCaptionTextTrack(tt)) {
           tt.mode = 'disabled';
         }
       }
@@ -164,15 +326,10 @@ const Webcams = () => {
 
         for (let i = 0; i < tts.length; i += 1) {
           const tt = tts[i];
-          if (!(tt && (tt.kind === 'captions' || tt.kind === 'subtitles'))) continue;
+          if (!isCaptionTextTrack(tt)) continue;
 
           if (tt.mode === 'showing') {
-            const labelLower = String(tt.label || '').toLowerCase();
-            const trackEl =
-              trackElsByLabel.current[labelLower] ||
-              element.current.querySelector(
-                `track[srclang="${(tt.language || '').toLowerCase()}"]`
-              );
+            const trackEl = getTrackElementForTextTrack(tt);
 
             loadVttSrc(trackEl);
           }
@@ -183,16 +340,66 @@ const Webcams = () => {
       textTracks.current.addEventListener('change', trackHandler.current);
       player.webcams.on('texttrackchange', trackHandler.current);
 
-      // Optional: auto-select a default caption (match UI locale)
-      const preferred = (storage?.locale || navigator.language || '').split('-')[0];
-      if (preferred) {
+      const selectCaptionByLocale = (rawLocale) => {
+        const normalizedTarget = normalizeLocale(rawLocale);
+        if (!normalizedTarget) return false;
+
         const tts = textTracks.current;
+        if (!tts) return false;
+
+        let fallbackMatch = null;
+
         for (let i = 0; i < tts.length; i += 1) {
           const tt = tts[i];
-          if ((tt.language || '').toLowerCase().startsWith(preferred.toLowerCase())) {
-            tt.mode = 'showing'; // triggers handler → loads real VTT
-            break;
+          if (!isCaptionTextTrack(tt)) continue;
+
+          const trackEl = getTrackElementForTextTrack(tt);
+          if (!trackEl) continue;
+
+          const trackLocale =
+            normalizeLocale(tt.language) ||
+            normalizeLocale(trackEl.srclang);
+
+          if (!trackLocale) continue;
+
+          if (trackLocale === normalizedTarget) {
+            tt.mode = 'showing';
+            loadVttSrc(trackEl);
+            return true;
           }
+
+          if (!fallbackMatch) {
+            const [targetLanguage] = normalizedTarget.split('-');
+            const [trackLanguage] = trackLocale.split('-');
+            if (targetLanguage && trackLanguage && targetLanguage === trackLanguage) {
+              fallbackMatch = { tt, trackEl };
+            }
+          }
+        }
+
+        if (fallbackMatch) {
+          fallbackMatch.tt.mode = 'showing';
+          loadVttSrc(fallbackMatch.trackEl);
+          return true;
+        }
+
+        return false;
+      };
+
+      // Auto-select caption defaulting to API-provided locale and browser locale fallback
+      const localeCandidates = [
+        defaultCaptionLocale.current,
+        navigator.language,
+      ].filter(Boolean);
+
+      for (let index = 0; index < localeCandidates.length; index += 1) {
+        const candidate = localeCandidates[index];
+        if (selectCaptionByLocale(candidate)) break;
+
+        const normalizedCandidate = normalizeLocale(candidate);
+        const [baseLanguage] = normalizedCandidate.split('-');
+        if (baseLanguage && baseLanguage !== normalizedCandidate) {
+          if (selectCaptionByLocale(baseLanguage)) break;
         }
       }
     });

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -1,20 +1,11 @@
 import React, { useEffect, useRef } from 'react';
-import {
-  defineMessages,
-  useIntl,
-} from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 import videojs from 'video.js/core.es.js';
 import { player as config } from 'config';
-import {
-  EVENTS,
-  ID,
-} from 'utils/constants';
+import { EVENTS, ID } from 'utils/constants';
 import { buildFileURL } from 'utils/data';
 import logger from 'utils/logger';
-import {
-  getFrequency,
-  getTime,
-} from 'utils/params';
+import { getFrequency, getTime } from 'utils/params';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
 import './index.scss';
@@ -28,59 +19,31 @@ const intlMessages = defineMessages({
 
 const buildSources = () => {
   if (storage.fallback) {
-    return [
-      {
-        src: buildFileURL('audio/audio.webm'),
-        type: 'audio/webm',
-      },
-    ];
+    return [{ src: buildFileURL('audio/audio.webm'), type: 'audio/webm' }];
   }
-
   return [
-    {
-      src: buildFileURL('video/webcams.mp4'),
-      type: 'video/mp4',
-    }, {
-      src: buildFileURL('video/webcams.webm'),
-      type: 'video/webm',
-    },
+    { src: buildFileURL('video/webcams.mp4'),  type: 'video/mp4'  },
+    { src: buildFileURL('video/webcams.webm'), type: 'video/webm' },
   ].filter(source => storage.media.find(m => source.type.includes(m)));
 };
 
-const buildTracks = () => {
-  return storage.captions.map(lang => {
-    const {
-      locale,
-      localeName,
-    } = lang;
-
-    return {
-      kind: 'captions',
-      src: buildFileURL(`caption_${locale}.vtt`),
-      srclang: locale,
-      label: localeName,
-    };
-  });
-};
-
-const buildOptions = (sources, tracks) => {
-  return {
-    controlBar: {
-      fullscreenToggle: false,
-      pictureInPictureToggle: false,
-      volumePanel: {
-        inline: false,
-        vertical: true,
-      },
-    },
-    controls: true,
-    fill: true,
-    inactivityTimeout: 0,
-    playbackRates: config.rates,
-    sources: sources.current,
-    tracks: tracks.current,
-  };
-};
+const buildOptions = (sources) => ({
+  autoplay: true,
+  controlBar: {
+    fullscreenToggle: false,
+    pictureInPictureToggle: false,
+    volumePanel: { inline: false, vertical: true },
+  },
+  controls: true,
+  fill: true,
+  inactivityTimeout: 0,
+  playbackRates: config.rates,
+  sources: sources.current,
+  // Important: use native text tracks so the browser fires the standard events
+  html5: {
+    nativeTextTracks: true,
+  },
+});
 
 const dispatchTimeUpdate = (time) => {
   const event = new CustomEvent(EVENTS.TIME_UPDATE, { detail: { time }});
@@ -89,56 +52,166 @@ const dispatchTimeUpdate = (time) => {
 
 const Webcams = () => {
   const intl = useIntl();
-  const sources = useRef(buildSources());
-  const tracks = useRef(buildTracks());
-  const element = useRef();
-  const interval = useRef();
+
+  const sources      = useRef(buildSources());
+  const tracks       = useRef(storage.captions || []); // [{ locale, localeName }]
+  const element      = useRef();
+  const interval     = useRef();
+  const textTracks   = useRef();
+  const trackHandler = useRef();
+  const trackElsByLabel = useRef({});
 
   useEffect(() => {
-    if (!player.webcams) {
-      const video = element.current;
-      if (!video) return;
+    if (player.webcams) return;
 
-      player.webcams = videojs(video, buildOptions(sources, tracks), () => {
-        player.webcams.on('play', () => {
-          const frequency = getFrequency();
-          interval.current = setInterval(() => {
-            const currentTime = player.webcams.currentTime();
-            dispatchTimeUpdate(currentTime);
-          }, 1000 / (frequency ? frequency : config.rps));
-        });
+    const video = element.current;
+    if (!video) return;
 
-        player.webcams.on('pause', () => clearInterval(interval.current));
+    // Clean any legacy track nodes
+    video.querySelectorAll('track').forEach(t => t.remove());
+    trackElsByLabel.current = {};
 
-        player.webcams.on('seeked', () => {
-          const currentTime = player.webcams.currentTime();
-          dispatchTimeUpdate(currentTime);
-        });
+    // Create <track> nodes WITHOUT src; stash the real URL in data attribute
+    tracks.current.forEach(({ locale, localeName }) => {
+      const el = document.createElement('track');
+      el.kind    = 'captions';
+      el.label   = localeName;
+      el.srclang = (locale || '').replace(/_/g, '-').toLowerCase();
+      // Do NOT set el.src now; we will attach it on selection
+      el.setAttribute('data-vtt-src', buildFileURL(`caption_${locale}.vtt`));
+      trackElsByLabel.current[String(localeName || '').toLowerCase()] = el;
+      video.appendChild(el);
+    });
 
-        const time = getTime();
-        if (time) {
-          player.webcams.on('loadedmetadata', () => {
-            const duration = player.webcams.duration();
-            if (time < duration) {
-              player.webcams.currentTime(time);
-            }
-          });
+    // Helper: robustly force a reload when we assign src the first time
+    const loadVttSrc = (trackEl) => {
+      if (!trackEl) return;
+      if (trackEl.dataset.loaded === 'true') return;
+
+      const realSrc = trackEl.dataset.vttSrc;
+      if (!realSrc) return;
+
+      // UX hint while we fetch
+      player.webcams?.addClass?.('vjs-waiting');
+
+      const onFinish = () => {
+        trackEl.dataset.loaded = 'true';
+        player.webcams?.removeClass?.('vjs-waiting');
+        trackEl.removeEventListener('load', onFinish);
+        trackEl.removeEventListener('error', onFinish);
+      };
+
+      trackEl.addEventListener('load', onFinish, { once: true });
+      trackEl.addEventListener('error', onFinish, { once: true });
+
+      // Some browsers ignore a single src mutation; clear first then set next tick
+      trackEl.setAttribute('src', '');
+      (window.requestAnimationFrame || setTimeout)(() => {
+        trackEl.setAttribute('src', realSrc);
+
+        // Ensure the native TextTrack becomes active after setting src
+        const nativeTrack = trackEl.track; // HTMLTrackElement.track (TextTrack)
+        if (nativeTrack) {
+          nativeTrack.mode = 'disabled';
+          (window.requestAnimationFrame || setTimeout)(() => {
+            nativeTrack.mode = 'showing';
+          }, 0);
         }
-      });
-      logger.debug(ID.WEBCAMS, 'mounted');
-    }
-  }, []);
+      }, 0);
+    };
 
-  useEffect(() => {
+    player.webcams = videojs(video, buildOptions(sources), () => {
+      player.webcams.play();
+
+      player.webcams.on('play', () => {
+        const frequency = getFrequency();
+        interval.current = setInterval(() => {
+          dispatchTimeUpdate(player.webcams.currentTime());
+        }, 1000 / (frequency || config.rps));
+      });
+
+      player.webcams.on('pause', () => {
+        clearInterval(interval.current);
+      });
+
+      player.webcams.on('seeked', () => {
+        dispatchTimeUpdate(player.webcams.currentTime());
+      });
+
+      const time = getTime();
+      if (time) {
+        player.webcams.on('loadedmetadata', () => {
+          const duration = player.webcams.duration();
+          if (time < duration) player.webcams.currentTime(time);
+        });
+      }
+
+      // captions lazy-load
+      textTracks.current = player.webcams.textTracks();
+
+      // Disable all initially (prevent auto show/load)
+      for (let i = 0; i < textTracks.current.length; i += 1) {
+        const tt = textTracks.current[i];
+        if (tt && (tt.kind === 'captions' || tt.kind === 'subtitles')) {
+          tt.mode = 'disabled';
+        }
+      }
+
+      // On caption selection, attach real src if needed and force it to load
+      trackHandler.current = () => {
+        const tts = textTracks.current;
+        if (!tts) return;
+
+        for (let i = 0; i < tts.length; i += 1) {
+          const tt = tts[i];
+          if (!(tt && (tt.kind === 'captions' || tt.kind === 'subtitles'))) continue;
+
+          if (tt.mode === 'showing') {
+            const labelLower = String(tt.label || '').toLowerCase();
+            const trackEl =
+              trackElsByLabel.current[labelLower] ||
+              element.current.querySelector(
+                `track[srclang="${(tt.language || '').toLowerCase()}"]`
+              );
+
+            loadVttSrc(trackEl);
+          }
+        }
+      };
+
+      // Cover both native and Video.js events
+      textTracks.current.addEventListener('change', trackHandler.current);
+      player.webcams.on('texttrackchange', trackHandler.current);
+
+      // Optional: auto-select a default caption (match UI locale)
+      const preferred = (storage?.locale || navigator.language || '').split('-')[0];
+      if (preferred) {
+        const tts = textTracks.current;
+        for (let i = 0; i < tts.length; i += 1) {
+          const tt = tts[i];
+          if ((tt.language || '').toLowerCase().startsWith(preferred.toLowerCase())) {
+            tt.mode = 'showing'; // triggers handler → loads real VTT
+            break;
+          }
+        }
+      }
+    });
+
+    logger.debug(ID.WEBCAMS, 'mounted');
+
     return () => {
       if (player.webcams) {
+        if (textTracks.current && trackHandler.current) {
+          textTracks.current.removeEventListener('change', trackHandler.current);
+          player.webcams?.off?.('texttrackchange', trackHandler.current);
+        }
+        clearInterval(interval.current);
         player.webcams.dispose();
         player.webcams = null;
-        logger.debug(ID.WEBCAMS, 'unmounted');
       }
+      logger.debug(ID.WEBCAMS, 'unmounted');
     };
   }, []);
-
 
   return (
     <div
@@ -151,6 +224,8 @@ const Webcams = () => {
           className="video-js"
           playsInline
           preload="auto"
+          // Set this when VTT or media may be on a different origin
+          crossOrigin="anonymous"
           ref={element}
         />
       </div>

--- a/src/utils/captions.js
+++ b/src/utils/captions.js
@@ -1,0 +1,387 @@
+import { buildFileURL } from 'utils/data';
+
+const CAPTION_TRACK_KINDS = ['captions', 'subtitles'];
+const WAITING_CLASS_NAME = 'vjs-waiting';
+
+const noop = () => {};
+
+const normalizeLocale = (locale) => {
+  if (!locale) return '';
+
+  return String(locale).replace(/_/g, '-').toLowerCase();
+};
+
+const getLocaleString = (value) => {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') {
+    return (
+      value.locale ||
+      value.language ||
+      value.lang ||
+      value.code ||
+      ''
+    );
+  }
+
+  return '';
+};
+
+const toArray = (value) => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'object') return Object.values(value);
+
+  return [];
+};
+
+const findDefaultLocale = (locales = []) => {
+  if (!Array.isArray(locales)) return '';
+
+  const defaultEntry = locales.find((item) => {
+    if (!item || typeof item !== 'object') return false;
+
+    return (
+      item.default === true ||
+      item.isDefault === true ||
+      item.defaultLocale === true ||
+      item.default_locale === true
+    );
+  });
+
+  if (!defaultEntry) return '';
+
+  return (
+    getLocaleString(defaultEntry.defaultLocale) ||
+    getLocaleString(defaultEntry.default_locale) ||
+    getLocaleString(defaultEntry)
+  );
+};
+
+const parseCaptionsData = (captionsData) => {
+  if (!captionsData) {
+    return { locales: [], defaultLocale: '' };
+  }
+
+  if (Array.isArray(captionsData)) {
+    return {
+      locales: captionsData,
+      defaultLocale: findDefaultLocale(captionsData),
+    };
+  }
+
+  if (typeof captionsData === 'object') {
+    const localesSource =
+      captionsData.locales ??
+      captionsData.captions ??
+      captionsData.locale ??
+      captionsData.tracks ??
+      captionsData.languages ??
+      null;
+
+    const locales = toArray(localesSource);
+
+    let defaultLocale =
+      getLocaleString(captionsData.defaultLocale) ||
+      getLocaleString(captionsData.default_locale) ||
+      getLocaleString(captionsData.default);
+
+    if (!defaultLocale) {
+      defaultLocale = findDefaultLocale(locales);
+    }
+
+    return {
+      locales,
+      defaultLocale,
+    };
+  }
+
+  return { locales: [], defaultLocale: '' };
+};
+
+const getTrackLocale = (track) => {
+  if (!track || typeof track !== 'object') return '';
+
+  return (
+    (typeof track.locale === 'string' && track.locale) ||
+    (typeof track.language === 'string' && track.language) ||
+    (typeof track.lang === 'string' && track.lang) ||
+    (typeof track.code === 'string' && track.code) ||
+    getLocaleString(track.defaultLocale) ||
+    getLocaleString(track.default_locale) ||
+    ''
+  );
+};
+
+const getTrackLabel = (track) => {
+  if (!track || typeof track !== 'object') return '';
+
+  return (
+    (typeof track.localeName === 'string' && track.localeName) ||
+    (typeof track.label === 'string' && track.label) ||
+    (typeof track.name === 'string' && track.name) ||
+    getTrackLocale(track)
+  );
+};
+
+const getTrackKind = (track) => {
+  if (!track || typeof track !== 'object') return 'captions';
+
+  const { kind } = track;
+  if (typeof kind === 'string' && CAPTION_TRACK_KINDS.includes(kind)) {
+    return kind;
+  }
+
+  return 'captions';
+};
+
+const getTrackSrc = (track, locale) => {
+  if (track && typeof track === 'object') {
+    const explicitSrc =
+      track.src ||
+      track.url ||
+      track.href ||
+      track.vtt ||
+      track.vttUrl ||
+      track.vttURL ||
+      track.caption ||
+      track.captionUrl ||
+      track.captionURL ||
+      track.caption_url ||
+      track.source;
+
+    if (typeof explicitSrc === 'string' && explicitSrc.length > 0) {
+      return explicitSrc;
+    }
+  }
+
+  if (!locale) return '';
+
+  return buildFileURL(`caption_${locale}.vtt`);
+};
+
+const isCaptionTextTrack = (textTrack) => {
+  if (!textTrack) return false;
+
+  return CAPTION_TRACK_KINDS.includes(textTrack.kind);
+};
+
+const setupLazyCaptions = ({
+  playerInstance,
+  videoElement,
+  tracks = [],
+  defaultLocale = '',
+  localeCandidates = [],
+} = {}) => {
+  if (!playerInstance || !videoElement) return noop;
+  if (!Array.isArray(tracks) || tracks.length === 0) return noop;
+
+  const trackElsByLabel = {};
+  const trackElsByLocale = {};
+
+  videoElement.querySelectorAll('track').forEach((t) => t.remove());
+
+  const createdTrackEls = tracks.reduce((acc, trackData) => {
+    const locale = getTrackLocale(trackData);
+    if (!locale) return acc;
+
+    const label = getTrackLabel(trackData) || locale;
+    const srclang = normalizeLocale(locale);
+    const src = getTrackSrc(trackData, locale);
+    if (!src) return acc;
+
+    const el = document.createElement('track');
+    el.kind = getTrackKind(trackData);
+    el.label = label;
+
+    if (srclang) el.srclang = srclang;
+
+    el.setAttribute('data-vtt-src', src);
+    el.dataset.loaded = 'false';
+    el.dataset.loading = 'false';
+
+    trackElsByLabel[String(label || '').toLowerCase()] = el;
+    if (srclang) trackElsByLocale[srclang] = el;
+
+    videoElement.appendChild(el);
+    acc.push(el);
+
+    return acc;
+  }, []);
+
+  if (createdTrackEls.length === 0) return noop;
+
+  const textTracks = typeof playerInstance.textTracks === 'function'
+    ? playerInstance.textTracks()
+    : null;
+
+  if (!textTracks) return noop;
+
+  for (let index = 0; index < textTracks.length; index += 1) {
+    const textTrack = textTracks[index];
+    if (isCaptionTextTrack(textTrack)) {
+      textTrack.mode = 'disabled';
+    }
+  }
+
+  const schedule =
+    (typeof window !== 'undefined' && window.requestAnimationFrame)
+      ? window.requestAnimationFrame.bind(window)
+      : (typeof window !== 'undefined' && window.setTimeout)
+        ? (fn) => window.setTimeout(fn, 0)
+        : (fn) => fn();
+
+  const loadVttSrc = (trackEl) => {
+    if (!trackEl) return;
+    if (trackEl.dataset.loaded === 'true') return;
+    if (trackEl.dataset.loading === 'true') return;
+
+    const realSrc = trackEl.dataset.vttSrc;
+    if (!realSrc) return;
+
+    trackEl.dataset.loading = 'true';
+    playerInstance?.addClass?.(WAITING_CLASS_NAME);
+
+    const onFinish = () => {
+      trackEl.dataset.loaded = 'true';
+      trackEl.dataset.loading = 'false';
+      playerInstance?.removeClass?.(WAITING_CLASS_NAME);
+      trackEl.removeEventListener('load', onFinish);
+      trackEl.removeEventListener('error', onFinish);
+    };
+
+    trackEl.addEventListener('load', onFinish, { once: true });
+    trackEl.addEventListener('error', onFinish, { once: true });
+
+    trackEl.setAttribute('src', '');
+    schedule(() => {
+      trackEl.setAttribute('src', realSrc);
+
+      const nativeTrack = trackEl.track;
+      if (nativeTrack) {
+        nativeTrack.mode = 'disabled';
+        schedule(() => {
+          nativeTrack.mode = 'showing';
+        });
+      }
+    });
+  };
+
+  const getTrackElementForTextTrack = (textTrack) => {
+    if (!textTrack) return null;
+
+    const language = normalizeLocale(textTrack.language);
+    const labelLower = String(textTrack.label || '').toLowerCase();
+
+    return (
+      (language && trackElsByLocale[language]) ||
+      trackElsByLabel[labelLower] ||
+      (language ? videoElement.querySelector(`track[srclang="${language}"]`) : null)
+    );
+  };
+
+  const trackHandler = () => {
+    for (let index = 0; index < textTracks.length; index += 1) {
+      const textTrack = textTracks[index];
+      if (!isCaptionTextTrack(textTrack)) continue;
+
+      if (textTrack.mode === 'showing') {
+        const trackEl = getTrackElementForTextTrack(textTrack);
+        loadVttSrc(trackEl);
+      }
+    }
+  };
+
+  if (textTracks.addEventListener) {
+    textTracks.addEventListener('change', trackHandler);
+  }
+  playerInstance?.on?.('texttrackchange', trackHandler);
+
+  const selectCaptionByLocale = (rawLocale) => {
+    const normalizedTarget = normalizeLocale(rawLocale);
+    if (!normalizedTarget) return false;
+
+    let fallbackMatch = null;
+
+    for (let index = 0; index < textTracks.length; index += 1) {
+      const textTrack = textTracks[index];
+      if (!isCaptionTextTrack(textTrack)) continue;
+
+      const trackEl = getTrackElementForTextTrack(textTrack);
+      if (!trackEl) continue;
+
+      const trackLocale =
+        normalizeLocale(textTrack.language) ||
+        normalizeLocale(trackEl.srclang);
+
+      if (!trackLocale) continue;
+
+      if (trackLocale === normalizedTarget) {
+        textTrack.mode = 'showing';
+        loadVttSrc(trackEl);
+        return true;
+      }
+
+      if (!fallbackMatch) {
+        const [targetLanguage] = normalizedTarget.split('-');
+        const [trackLanguage] = trackLocale.split('-');
+
+        if (targetLanguage && trackLanguage && targetLanguage === trackLanguage) {
+          fallbackMatch = { textTrack, trackEl };
+        }
+      }
+    }
+
+    if (fallbackMatch) {
+      fallbackMatch.textTrack.mode = 'showing';
+      loadVttSrc(fallbackMatch.trackEl);
+      return true;
+    }
+
+    return false;
+  };
+
+  const candidateOrder = [];
+  const seen = new Set();
+  const maybeAddCandidate = (candidate) => {
+    if (!candidate) return;
+    if (seen.has(candidate)) return;
+    seen.add(candidate);
+    candidateOrder.push(candidate);
+  };
+
+  maybeAddCandidate(defaultLocale);
+  if (Array.isArray(localeCandidates)) {
+    localeCandidates.forEach(maybeAddCandidate);
+  }
+  if (typeof navigator !== 'undefined') {
+    maybeAddCandidate(navigator.language);
+  }
+
+  candidateOrder.some((candidate) => {
+    if (selectCaptionByLocale(candidate)) return true;
+
+    const normalizedCandidate = normalizeLocale(candidate);
+    if (!normalizedCandidate) return false;
+
+    const [baseLanguage] = normalizedCandidate.split('-');
+    if (baseLanguage && baseLanguage !== normalizedCandidate) {
+      return selectCaptionByLocale(baseLanguage);
+    }
+
+    return false;
+  });
+
+  return () => {
+    if (textTracks.removeEventListener) {
+      textTracks.removeEventListener('change', trackHandler);
+    }
+    playerInstance?.off?.('texttrackchange', trackHandler);
+  };
+};
+
+export {
+  normalizeLocale,
+  parseCaptionsData,
+  setupLazyCaptions,
+};


### PR DESCRIPTION
## Summary
- add helpers to normalize captions metadata and build text track nodes without eager loading VTT sources
- lazy load caption files when tracks are activated and prevent duplicate fetches while a load is in-flight
- prefer the default locale returned by the captions/locales API when auto-selecting captions, with browser language as fallback

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce992c5e10832a885281bff257f91f